### PR TITLE
Tobi/data type conventions

### DIFF
--- a/model/entities/trader.py
+++ b/model/entities/trader.py
@@ -41,11 +41,11 @@ class Trader(Account):
         """
         order = self.strategy.return_optimal_trade(params, prev_state)
         if order is None:
-            return dict(
-                mento_buckets=prev_state["mento_buckets"],
-                floating_supply=prev_state["floating_supply"],
-                reserve_balance=prev_state["reserve_balance"],
-            )
+            return {
+                "mento_buckets": prev_state["mento_buckets"],
+                "floating_supply": prev_state["floating_supply"],
+                "reserve_balance": prev_state["reserve_balance"],
+            }
 
         sell_amount = order["sell_amount"]
         sell_gold = order["sell_gold"]
@@ -59,10 +59,11 @@ class Trader(Account):
         self.parent.reserve.balance += Balance(celo=-deltas["celo"], cusd=0)
 
 
-        return dict(
-            mento_buckets=mento_buckets,
-            floating_supply=self.parent.floating_supply.__dict__,
-            reserve_balance=self.parent.reserve.balance.__dict__)
+        return {
+            "mento_buckets": mento_buckets,
+            "floating_supply": self.parent.floating_supply.__dict__,
+            "reserve_balance": self.parent.reserve.balance.__dict__
+        }
 
     def rebalance_portfolio(self, target_amount, target_is_celo, prev_state):
         """

--- a/model/generators/accounts.py
+++ b/model/generators/accounts.py
@@ -79,14 +79,6 @@ class AccountGenerator(Generator):
         self.accounts_by_id[account.account_id] = account
         return account
 
-    def get_save_balances_policy(self):
-        def policy(_params, _substep, _state_history, _prev_state):
-            return dict(
-                reserve_balance=self.reserve.balance.__dict__,
-                floating_supply=self.floating_supply.__dict__,
-            )
-        return policy
-
     @state_update_blocks("traders")
     def traders_execute(self):
         return [

--- a/model/generators/accounts.py
+++ b/model/generators/accounts.py
@@ -79,21 +79,6 @@ class AccountGenerator(Generator):
         self.accounts_by_id[account.account_id] = account
         return account
 
-    @state_update_blocks("checkpoint")
-    def checkpoint_balances(self):
-        return [{
-            "description": """
-            Checkpoint accounts generator totals to simulation state
-            """,
-            'policies': {
-                'save_balances': self.get_save_balances_policy()
-            },
-            'variables': {
-                'reserve_balance': update_from_signal('reserve_balance'),
-                'floating_supply': update_from_signal('floating_supply')
-            }
-        }]
-
     def get_save_balances_policy(self):
         def policy(_params, _substep, _state_history, _prev_state):
             return dict(

--- a/model/parts/celo_system.py
+++ b/model/parts/celo_system.py
@@ -20,10 +20,10 @@ def p_epoch_rewards(_params, _substep, _state_history, prev_state,
 
     is_not_epoch_block = ((prev_state['timestep'] * blocktime_seconds) % seconds_per_epoch) != 0
     if is_not_epoch_block or prev_state['timestep'] == 0:
-        return dict(
-            floating_supply=prev_state["floating_supply"],
-            reserve_balance=prev_state["reserve_balance"],
-        )
+        return {
+            "floating_supply": prev_state["floating_supply"],
+            "reserve_balance": prev_state["reserve_balance"],
+        }
 
     validator_rewards = 0.07 * target_epoch_rewards_downscaled
     celo_rewards = target_epoch_rewards_downscaled - validator_rewards
@@ -38,6 +38,7 @@ def p_epoch_rewards(_params, _substep, _state_history, prev_state,
         cusd=validator_rewards_in_cusd
     )
 
-    return dict(
-        floating_supply=account_generator.floating_supply.__dict__,
-        reserve_balance=account_generator.reserve.balance.__dict__)
+    return {
+        "floating_supply": account_generator.floating_supply.__dict__,
+        "reserve_balance": account_generator.reserve.balance.__dict__
+    }

--- a/model/state_update_blocks.py
+++ b/model/state_update_blocks.py
@@ -71,7 +71,6 @@ _state_update_blocks = [
     state_update_block_periodic_mento_bucket_update,
     generator_state_update_block(AccountGenerator, "traders"),
     state_update_block_epoch_rewards,
-    # generator_state_update_block(AccountGenerator, "checkpoint"),
     state_update_block_price_impact,
 ]
 


### PR DESCRIPTION
While `dict()` is better for readability, {} is faster and used as default in the python community. Refactoring the few dict() usages to {} here and removing some dead code as a byproduct