### PR TITLE
Fix random number seeding

### DIFF
--- a/experiments/simulation_configuration.py
+++ b/experiments/simulation_configuration.py
@@ -8,6 +8,6 @@ SIMULATION_TIME_DAYS = 1  # number of days
 # number of simulation_configuration timesteps
 TIMESTEPS = SIMULATION_TIME_DAYS * blocks_per_day // BLOCKS_PER_TIMESTEP
 TIMESTEPS_PER_YEAR = blocks_per_year // BLOCKS_PER_TIMESTEP
-MONTE_CARLO_RUNS = 1  # number of runs
+MONTE_CARLO_RUNS = 2  # number of runs
 DATA_SOURCE = 'historical'   # 'mock' or 'historical'
 TOTAL_BLOCKS = (BLOCKS_PER_TIMESTEP * TIMESTEPS) + 1

--- a/model/constants.py
+++ b/model/constants.py
@@ -17,5 +17,3 @@ celo_total_epoch_rewards = celo_max_supply - celo_genesis_supply
 celo_linear_total_epoch_rewards = celo_total_epoch_rewards / 2
 target_epoch_rewards = celo_linear_total_epoch_rewards / 15 / 365
 target_epoch_rewards_downscaled = target_epoch_rewards * 0.8
-
-global_rng_entropy = 1000

--- a/model/entities/oracle_provider.py
+++ b/model/entities/oracle_provider.py
@@ -5,8 +5,8 @@ Provides OracleProvider class for OracleRateGenerator
 from typing import List
 from uuid import UUID
 from model.types import OracleConfig, Pair
-from model.utils.rng_provider import rngp
 from model.constants import blocktime_seconds
+from model.utils.rng_provider import RNGProvider
 
 
 class OracleProvider():
@@ -17,7 +17,14 @@ class OracleProvider():
     id_: UUID
     config: OracleConfig
 
-    def __init__(self, name: str, oracle_id: UUID, config: OracleConfig, pairs: List[Pair]):
+    def __init__(
+        self,
+        name: str,
+        oracle_id: UUID,
+        config: OracleConfig,
+        pairs: List[Pair],
+        rngp: RNGProvider
+    ):
         self.name = name
         self.orace_id = oracle_id
         self.config = config

--- a/model/entities/strategies/strategy_random_trader.py
+++ b/model/entities/strategies/strategy_random_trader.py
@@ -5,7 +5,6 @@ from cvxpy import Variable
 import numpy as np
 
 from experiments import simulation_configuration
-from model.utils.rng_provider import rngp
 
 from .trader_strategy import TraderStrategy
 
@@ -19,7 +18,7 @@ class RandomTrading(TraderStrategy):
         super().__init__(parent, acting_frequency)
         self.generate_sell_amounts()
         self.sell_amount = None
-        self.rng = rngp.get_rng("RandomTrader", self.parent.account_id)
+        self.rng = parent.rngp.get_rng("RandomTrader", self.parent.account_id)
 
     def sell_reserve_asset(self, _params, prev_state):
         return self.orders[prev_state["timestep"]]["sell_reserve_asset"]

--- a/model/entities/trader.py
+++ b/model/entities/trader.py
@@ -11,6 +11,7 @@ from model.generators.mento import MentoExchangeGenerator
 from model.entities import strategies
 from model.entities.account import Account, Balance
 from model.types import MentoExchangeConfig, Pair, TraderConfig
+from model.utils.rng_provider import RNGProvider
 
 if TYPE_CHECKING:
     from model.generators.accounts import AccountGenerator
@@ -23,6 +24,7 @@ class Trader(Account):
     config: TraderConfig
     exchange_config: MentoExchangeConfig
     mento: MentoExchangeGenerator
+    rngp: RNGProvider
 
     def __init__(
         self,
@@ -30,8 +32,10 @@ class Trader(Account):
         account_id: UUID,
         account_name: str,
         config: TraderConfig,
+        rngp: RNGProvider
     ):
         super().__init__(parent, account_id, account_name, config.balance)
+        self.rngp = rngp
         self.mento = self.parent.container.get(MentoExchangeGenerator)
         self.config = config
         self.exchange_config = self.mento.configs.get(self.config.exchange)

--- a/model/generators/accounts.py
+++ b/model/generators/accounts.py
@@ -13,6 +13,7 @@ from model.types import TraderConfig
 from model.utils import update_from_signal
 from model.utils.generator import Generator, state_update_blocks
 from model.utils.generator_container import GeneratorContainer
+from model.utils.rng_provider import RNGProvider
 
 ACCOUNTS_NS = uuid4()
 
@@ -28,13 +29,16 @@ class AccountGenerator(Generator):
     # generator.
     untracked_floating_supply: Balance
     container: GeneratorContainer
+    rngp: RNGProvider
 
     def __init__(self,
                 reserve_inventory: Balance,
                 initial_floating_supply: Balance,
                 traders: List[TraderConfig],
-                container: GeneratorContainer):
+                container: GeneratorContainer,
+                rngp: RNGProvider):
         self.container = container
+        self.rngp = rngp
         self.reserve = self.create_reserve_account(
             initial_balance=reserve_inventory
         )
@@ -55,6 +59,7 @@ class AccountGenerator(Generator):
             Balance(initial_state["floating_supply"]),
             params["traders"],
             container,
+            params["rngp"]
         )
 
         return accounts
@@ -76,7 +81,8 @@ class AccountGenerator(Generator):
             self,
             account_id=uuid5(ACCOUNTS_NS, account_name),
             account_name=account_name,
-            config=config
+            config=config,
+            rngp=self.rngp
         )
         self.accounts_by_id[account.account_id] = account
         return account

--- a/model/generators/markets.py
+++ b/model/generators/markets.py
@@ -13,7 +13,7 @@ from model.utils.data_feed import DATA_FOLDER, DataFeed
 from model.utils.generator import Generator
 from model.utils.price_impact_valuator import PriceImpactValuator
 from model.utils.quantlib_wrapper import QuantLibWrapper
-from model.utils.rng_provider import rngp
+from model.utils.rng_provider import RNGProvider
 
 # raise numpy warnings as errors
 np.seterr(all='raise')
@@ -35,6 +35,7 @@ class MarketPriceGenerator(Generator):
         self,
         model,
         impacted_assets,
+        rngp: RNGProvider,
         increments=None,
     ):
         self.model = model
@@ -49,9 +50,10 @@ class MarketPriceGenerator(Generator):
         if model == MarketPriceModel.QUANTLIB:
             market_price_generator = cls(
                 model,
-                params['impacted_assets']
+                params['impacted_assets'],
+                params['rngp']
             )
-            seed_sequence = rngp.__seed__("MarketPriceGenerator")
+            seed_sequence = params['rngp'].__seed__(["QuantLib"])
             quant_lib_seed = int(seed_sequence.generate_state(1)[0])
             quant_lib_wrapper = QuantLibWrapper(
                 params['market_price_processes'],
@@ -61,13 +63,13 @@ class MarketPriceGenerator(Generator):
             )
             market_price_generator.increments = quant_lib_wrapper.correlated_returns()
         elif model == MarketPriceModel.PRICE_IMPACT:
-            market_price_generator = cls(model, params['impacted_assets'])
+            market_price_generator = cls(model, params['impacted_assets'], params['rngp'])
         elif model == MarketPriceModel.HIST_SIM:
-            market_price_generator = cls(model, params['impacted_assets'])
+            market_price_generator = cls(model, params['impacted_assets'], params['rngp'])
             market_price_generator.historical_returns()
             logging.info("increments updated")
         elif model == MarketPriceModel.SCENARIO:
-            market_price_generator = cls(model, params['impacted_assets'])
+            market_price_generator = cls(model, params['impacted_assets'], params['rngp'])
             market_price_generator.historical_returns()
             logging.info("increments updated")
         return market_price_generator

--- a/model/generators/oracles.py
+++ b/model/generators/oracles.py
@@ -28,7 +28,6 @@ class OracleRateGenerator(Generator):
     oracles_by_pair: Dict[Pair, List[OracleProvider]]
     oracle_pairs: List[Pair]
     rngp: RNGProvider
-    rng: np.random.Generator
 
     def __init__(
         self,
@@ -38,7 +37,6 @@ class OracleRateGenerator(Generator):
     ):
         self.input = None
         self.rngp = rngp
-        self.rng = rngp.get_rng("OracleGenerator")
         self.oracle_pairs = oracle_pairs
         self.oracles_by_pair = {pair: [] for pair in oracle_pairs}
         self.oracles_by_id = {}

--- a/model/generators/oracles.py
+++ b/model/generators/oracles.py
@@ -11,7 +11,7 @@ from model.entities.oracle_provider import OracleProvider
 from model.types import OracleConfig, Pair
 from model.utils import update_from_signal
 from model.utils.generator import Generator, state_update_blocks
-from model.utils.rng_provider import rngp
+from model.utils.rng_provider import RNGProvider
 
 ORACLES_NS = uuid4()
 
@@ -27,13 +27,17 @@ class OracleRateGenerator(Generator):
     oracles_by_id: Dict[UUID, OracleProvider]
     oracles_by_pair: Dict[Pair, List[OracleProvider]]
     oracle_pairs: List[Pair]
+    rngp: RNGProvider
+    rng: np.random.Generator
 
     def __init__(
         self,
         oracles: List[OracleConfig],
-        oracle_pairs: List[Pair]
+        oracle_pairs: List[Pair],
+        rngp: RNGProvider
     ):
         self.input = None
+        self.rngp = rngp
         self.rng = rngp.get_rng("OracleGenerator")
         self.oracle_pairs = oracle_pairs
         self.oracles_by_pair = {pair: [] for pair in oracle_pairs}
@@ -44,7 +48,7 @@ class OracleRateGenerator(Generator):
 
     @classmethod
     def from_parameters(cls, params, _initial_state, _container):
-        oracle_generator = cls(params['oracles'], params['oracle_pairs'])
+        oracle_generator = cls(params['oracles'], params['oracle_pairs'], params['rngp'])
         return oracle_generator
 
     def create_oracle(self, index: int, oracle_config: OracleConfig, oracle_pairs: List[Pair]):
@@ -57,7 +61,8 @@ class OracleRateGenerator(Generator):
         oracle_provider = OracleProvider(name=oracle_name,
                                          oracle_id=oracle_id,
                                          config=oracle_config,
-                                         pairs=oracle_pairs)
+                                         pairs=oracle_pairs,
+                                         rngp=self.rngp)
         self.oracles_by_id[oracle_id] = oracle_provider
         for pair in self.oracle_pairs:
             self.oracles_by_pair[pair].append(oracle_provider)

--- a/model/system_parameters.py
+++ b/model/system_parameters.py
@@ -27,6 +27,7 @@ from model.types import (
     TraderConfig,
     TraderType,
 )
+from model.utils.rng_provider import RNGProvider
 
 
 class Parameters(TypedDict):
@@ -35,6 +36,8 @@ class Parameters(TypedDict):
     after the parameter sweep.
     Used as type annotation for functions that take params.
     """
+    rng_seed: int
+    rngp: RNGProvider
     mento_exchanges_config: Dict[Stable, MentoExchangeConfig]
     mento_exchanges_active: List[MentoExchange]
     market_price_model: MarketPriceModel
@@ -54,6 +57,7 @@ class InitParameters(TypedDict):
     Each System Parameter is defined as:
     system parameter key: system parameter type = default system parameter value
     """
+    rng_seed: List[int]
     mento_exchanges_config: List[Dict[Stable, MentoExchangeConfig]]
     mento_exchanges_active: List[List[MentoExchange]]
     market_price_model: List[MarketPriceModel]
@@ -70,6 +74,7 @@ class InitParameters(TypedDict):
 
 
 parameters = InitParameters(
+    rng_seed=[1000],
     # Configuration params for each stable's exchange
     mento_exchanges_config=[{
         MentoExchange.CUSD_CELO: MentoExchangeConfig(

--- a/model/utils/engine.py
+++ b/model/utils/engine.py
@@ -2,10 +2,21 @@
 radCAD Engine extension to give us more control over how simulations happen
 """
 import copy
+from functools import reduce
+from typing import Any, Callable, Dict, List, NamedTuple
 from radcad.engine import Engine as RadCadEngine
 from radcad import core, wrappers
 
+from model.utils.rng_provider import RNGProvider
+
 from .generator_container import GENERATOR_CONTAINER_PARAM_KEY, GeneratorContainer
+
+
+class SimulationConfig(NamedTuple):
+    params: Dict[str, Any]
+    state: Dict[str, Any]
+    state_update_blocks: List[Any]
+    run_index: int
 
 # pylint: disable=too-many-locals,protected-access,too-few-public-methods
 class Engine(RadCadEngine):
@@ -54,18 +65,19 @@ class Engine(RadCadEngine):
                             params
                         )
                         self.executable._before_subset(context=context)
-                        params_for_run = __inject_generator_container__(param_set, initial_state)
-                        state_update_blocks_for_run = __hydrate_state_update_blocks__(
-                            state_update_blocks,
-                            params_for_run)
+                        config = __prepare_simulation_config__(SimulationConfig(
+                                param_set,
+                                initial_state,
+                                state_update_blocks,
+                                run_index))
                         yield wrappers.RunArgs(
                             simulation_index,
                             timesteps,
                             run_index,
                             subset_index,
-                            copy.deepcopy(initial_state),
-                            state_update_blocks_for_run,
-                            params_for_run,
+                            copy.deepcopy(config.state),
+                            config.state_update_blocks,
+                            config.params,
                             self.deepcopy,
                             self.drop_substeps)
                         self.executable._after_subset(context=context)
@@ -81,19 +93,20 @@ class Engine(RadCadEngine):
                     self.executable._before_run(context=context)
                     self.executable._before_subset(context=context)
 
-                    params_for_run = __inject_generator_container__(param_set, initial_state)
-                    state_update_blocks_for_run = __hydrate_state_update_blocks__(
-                        state_update_blocks,
-                        params_for_run)
+                    config = __prepare_simulation_config__(SimulationConfig(
+                            param_set,
+                            initial_state,
+                            state_update_blocks,
+                            run_index))
 
                     yield wrappers.RunArgs(
                         simulation_index,
                         timesteps,
                         run_index,
                         0,
-                        copy.deepcopy(initial_state),
-                        state_update_blocks_for_run,
-                        params_for_run,
+                        copy.deepcopy(config.state),
+                        config.state_update_blocks,
+                        config.params,
                         self.deepcopy,
                         self.drop_substeps,
                     )
@@ -104,23 +117,46 @@ class Engine(RadCadEngine):
                 simulation=simulation
             )
 
-def __inject_generator_container__(params, initial_state):
-    params.update({
+def __inject_rng_provider__(config: SimulationConfig):
+    config.params.update({
+        'rngp': RNGProvider(config.params['rng_seed'], config.run_index)
+    })
+    return config
+
+def __inject_generator_container__(config: SimulationConfig):
+    config.params.update({
         GENERATOR_CONTAINER_PARAM_KEY: GeneratorContainer(
-            copy.deepcopy(params),
-            copy.deepcopy(initial_state)
+            copy.deepcopy(config.params),
+            copy.deepcopy(config.state)
         )
     })
-    return params
+    return config
 
-def __hydrate_state_update_blocks__(state_update_blocks, params):
-    container = params.get(GENERATOR_CONTAINER_PARAM_KEY)
+def __hydrate_state_update_blocks__(config: SimulationConfig):
+    container = config.params.get(GENERATOR_CONTAINER_PARAM_KEY)
     flat_state_update_blocks = []
-    for state_update_block in state_update_blocks:
+    for state_update_block in config.state_update_blocks:
         if state_update_block.get('type') == 'generator':
             generator = container.get(state_update_block.get('source'))
             selectors = state_update_block.get('selectors', [])
             flat_state_update_blocks += generator.state_update_blocks(selectors)
         else:
             flat_state_update_blocks += [state_update_block]
-    return flat_state_update_blocks
+
+    return SimulationConfig(
+        config.params,
+        config.state,
+        flat_state_update_blocks,
+        config.run_index
+    )
+
+SimulationConfigModifier = Callable[[SimulationConfig], SimulationConfig]
+
+MODIFIERS: List[SimulationConfigModifier] = [
+    __inject_rng_provider__,
+    __inject_generator_container__,
+    __hydrate_state_update_blocks__,
+]
+
+def __prepare_simulation_config__(config: SimulationConfig) -> SimulationConfig:
+    return reduce(lambda config, modifier: modifier(config), MODIFIERS, config)

--- a/model/utils/rng_provider.py
+++ b/model/utils/rng_provider.py
@@ -5,27 +5,35 @@ a level of consistency in the random numbers as the structure
 of the simulation changes.
 """
 
+import hashlib
+import logging
 from typing import List, Union
 import numpy as np
-from model.constants import global_rng_entropy
+# from model.constants import global_rng_entropy
 
 class RNGProvider():
     """
     RNGProvider providers randum number generators based
     on a global entropy and contexts
     """
-    entropy: int
+    seed: int
+    monte_carlo_run: int
 
-    def __init__(self, entropy: int):
-        self.entropy = entropy
+    def __init__(self, seed: int, monte_carlo_run: int):
+        self.seed = seed
+        self.monte_carlo_run = monte_carlo_run
 
     def get_rng(self, *context: List[Union[str, int]]) -> np.random.Generator:
-        return np.random.default_rng(self.__seed__(context))
+        return np.random.default_rng(self.__seed__(list(context)))
 
     def __seed__(self, context: List[Union[str, int]]) -> np.random.SeedSequence:
-        return np.random.SeedSequence(
-            self.entropy,
-            spawn_key=map(abs, map(hash, context))
+        seed_sequence = np.random.SeedSequence(
+            self.seed,
+            spawn_key=map(abs, map(__hash__, [self.monte_carlo_run] + context))
         )
+        logging.debug("Generated seed_sequence %s for context %s", seed_sequence, context)
+        return seed_sequence
 
-rngp = RNGProvider(global_rng_entropy)
+def __hash__(val: Union[str, int]) -> int:
+    hex_hash = hashlib.md5(str(val).encode()).hexdigest()[0:16]
+    return int(hex_hash, base=16)

--- a/model/utils/rng_provider.py
+++ b/model/utils/rng_provider.py
@@ -29,7 +29,7 @@ class RNGProvider():
     def __seed__(self, context: List[Union[str, int]]) -> np.random.SeedSequence:
         seed_sequence = np.random.SeedSequence(
             self.seed,
-            spawn_key=map(abs, map(__hash__, [self.monte_carlo_run] + context))
+            spawn_key=map(__hash__, [self.monte_carlo_run] + context)
         )
         logging.debug("Generated seed_sequence %s for context %s", seed_sequence, context)
         return seed_sequence


### PR DESCRIPTION
While working on linking the random numbers to quanlib @sissnad identified some issues with the RNG logic. This PR addresses two major issues:

1. **Random number seeds were not consistent between runs**: This was due to the builtin `hash` function not being consistent across runs. I replaced that with a slightly convoluted usage of `hashlib.md5` to extract a truncated int from it as the seed generators use ints in the seed sequence.
2. **Different monte carlo runs were not affecting the RNGs seed sequence**: In order to fix this I opted to move from the current singleton approach from the RNGProvider to an approach where I inject it via the `Engine` as part of the params. This way we can control how it's initialized for each run according to the `run_index` and include that as part of the seed sequence under the hood. This way different montecarlo runs will generate different seed sequences.